### PR TITLE
docs: voeg Nederlandstalige documentatie toe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,95 @@
-# AI-RAG: Retrieval-Augmented Generation with Pinecone and Ollama
+# AI-RAG: Retrieval-Augmented Generation met Pinecone en Ollama
 
-This project demonstrates a Retrieval-Augmented Generation (RAG) pipeline using Python, LangChain, Pinecone, and Ollama.
-It ingests FAQ data, stores question-answer pairs in a vector database, and answers user queries using a local LLM.
+Dit project demonstreert een Retrieval-Augmented Generation (RAG) pipeline met Python, LangChain, Pinecone en Ollama.
+Het neemt FAQ-gegevens op, slaat vraag-antwoordparen op in een vectordatabase en beantwoordt gebruikersvragen met een lokaal LLM.
 
-## Features
+## Functionaliteiten
 
-- Ingests FAQ data from JSON or PDF
-- Splits and embeds documents using Ollama
-- Stores embeddings in Pinecone vector database
-- Retrieves relevant context for user questions
-- Uses a local LLM (Ollama) to generate answers based on retrieved context
-- Environment configuration via .env file
+- Neemt FAQ-gegevens op vanuit JSON of PDF
+- Splitst en embed documenten met Ollama
+- Slaat embeddings op in een Pinecone vectordatabase
+- Haalt relevante context op voor gebruikersvragen
+- Gebruikt een lokaal LLM (Ollama) om antwoorden te genereren op basis van opgehaalde context
+- Omgevingsconfiguratie via .env-bestand
 
-## Setup
+## Installatie
 
-**Configure environment variables**
-   - Edit .env in the project root:
+**Omgevingsvariabelen configureren**
+   - Bewerk .env in de projectroot:
      ```
-     PINECONE_API_KEY=your_pinecone_api_key
-     PINECONE_HOST=your_pinecone_host_url
-     PINECONE_LANG=your_pinecone_host_url_lang_version
+     PINECONE_API_KEY=jouw_pinecone_api_sleutel
+     PINECONE_HOST=jouw_pinecone_host_url
+     PINECONE_LANG=jouw_pinecone_host_url_lang_versie
      OLLAMA_API_URL=http://localhost:11434
      ```
-**Start Ollama**
-   - Install and run Ollama locally: [Ollama documentation](https://ollama.com/)
-   - Pull required models (e.g., `ollama pull all-minilm:l6-v2`)
+**Ollama starten**
+   - Installeer en start Ollama lokaal: [Ollama-documentatie](https://ollama.com/)
+   - Pull de benodigde modellen (bijv. `ollama pull all-minilm:l6-v2`)
 
-## Usage
+## Gebruik
 
-The project includes two independent implementations of the RAG pipeline:
+Het project bevat twee onafhankelijke implementaties van de RAG-pipeline:
 
-### `lang/` — LangChain-based pipeline
+### `lang/` -- Pipeline op basis van LangChain
 
-Uses LangChain abstractions for document handling, embedding, retrieval, and LLM orchestration.
+Gebruikt LangChain-abstracties voor documentverwerking, embedding, retrieval en LLM-orchestratie.
 
-1. **Ingest FAQ data** — run `lang/ingest.py` to load `data/faq.json` into Pinecone.
+1. **FAQ-gegevens opnemen** -- voer `lang/ingest.py` uit om `data/faq.json` in Pinecone te laden.
    ```bash
    cd lang
    python ingest.py
    ```
-2. **Query** — run `lang/main.py` for an interactive Q&A loop.
+2. **Vragen stellen** -- voer `lang/main.py` uit voor een interactieve vraag-en-antwoordlus.
    ```bash
    python main.py
    ```
 
 | Component | Detail |
 |---|---|
-| Embedding model | `all-minilm:l6-v2` (384 dims) |
+| Embeddingmodel | `all-minilm:l6-v2` (384 dimensies) |
 | LLM | `qwen2.5:7b-instruct` |
-| Index name | `faq-rag-test` |
+| Indexnaam | `faq-rag-test` |
 
-### `manual/` — Lightweight pipeline (no LangChain)
+### `manual/` -- Lichtgewicht pipeline (zonder LangChain)
 
-Calls the Ollama and Pinecone REST APIs directly — useful for understanding what LangChain abstracts away.
+Roept de Ollama- en Pinecone REST API's direct aan -- handig om te begrijpen wat LangChain abstraheert.
 
-1. **Ingest a PDF** — run `manual/ingest.py` to extract text from `data/info.pdf`, chunk it, and upsert into Pinecone.
+1. **Een PDF opnemen** -- voer `manual/ingest.py` uit om tekst uit `data/info.pdf` te extraheren, op te splitsen en in Pinecone op te slaan.
    ```bash
    cd manual
    python ingest.py
    ```
-2. **Query** — run `manual/query.py` to ask a single question and get a concise answer.
+2. **Vragen stellen** -- voer `manual/query.py` uit om een enkele vraag te stellen en een beknopt antwoord te krijgen.
    ```bash
    python query.py
    ```
 
 | Component | Detail |
 |---|---|
-| Embedding model | `nomic-embed-text:latest` (768 dims) |
+| Embeddingmodel | `nomic-embed-text:latest` (768 dimensies) |
 | LLM | `qwen2.5:0.5b` |
-| Index name | `pdf-rag-test` |
+| Indexnaam | `pdf-rag-test` |
 
-## File Structure
+## Bestandsstructuur
 
 ```
 .
 ├── data/
-│   ├── faq.json          # FAQ dataset (used by lang/)
-│   └── info.pdf          # PDF document (used by manual/)
+│   ├── faq.json          # FAQ-dataset (gebruikt door lang/)
+│   └── info.pdf          # PDF-document (gebruikt door manual/)
 ├── lang/
-│   ├── ingest.py         # LangChain-based FAQ ingestion
-│   └── main.py           # LangChain-based interactive Q&A
+│   ├── ingest.py         # FAQ-opname via LangChain
+│   └── main.py           # Interactieve Q&A via LangChain
 ├── manual/
-│   ├── ingest.py         # Direct-API PDF ingestion
-│   └── query.py          # Direct-API single-question query
+│   ├── ingest.py         # PDF-opname via directe API-aanroepen
+│   └── query.py          # Enkele-vraag query via directe API-aanroepen
 ├── requirements.txt
-├── .env                  # Environment variables (not committed)
+├── .env                  # Omgevingsvariabelen (niet gecommit)
 └── README.md
 ```
 
-## Notes
+## Opmerkingen
 
-- Make sure your Pinecone index dimension matches your embedding model output (`lang/` uses 384, `manual/` uses 768).
-- For best results, store both questions and answers together in each document.
-- You can adjust chunk size and retrieval parameters in the code.
+- Zorg ervoor dat de dimensie van je Pinecone-index overeenkomt met de output van je embeddingmodel (`lang/` gebruikt 384, `manual/` gebruikt 768).
+- Sla voor de beste resultaten zowel vragen als antwoorden samen op in elk document.
+- Je kunt de chunkgrootte en retrievalparameters aanpassen in de code.

--- a/README.md
+++ b/README.md
@@ -28,34 +28,68 @@ It ingests FAQ data, stores question-answer pairs in a vector database, and answ
 
 ## Usage
 
-### Ingest FAQ Data
+The project includes two independent implementations of the RAG pipeline:
 
-- Edit and run `lang/ingest.py` to ingest FAQ data from `data/faq.json` into Pinecone.
+### `lang/` — LangChain-based pipeline
 
-### Query the System
+Uses LangChain abstractions for document handling, embedding, retrieval, and LLM orchestration.
 
-- Run `lang/main.py` to start the interactive question-answering loop:
-  ```bash
-  python main.py
-  ```
-- Type your question and get an answer based on the retrieved context.
+1. **Ingest FAQ data** — run `lang/ingest.py` to load `data/faq.json` into Pinecone.
+   ```bash
+   cd lang
+   python ingest.py
+   ```
+2. **Query** — run `lang/main.py` for an interactive Q&A loop.
+   ```bash
+   python main.py
+   ```
+
+| Component | Detail |
+|---|---|
+| Embedding model | `all-minilm:l6-v2` (384 dims) |
+| LLM | `qwen2.5:7b-instruct` |
+| Index name | `faq-rag-test` |
+
+### `manual/` — Lightweight pipeline (no LangChain)
+
+Calls the Ollama and Pinecone REST APIs directly — useful for understanding what LangChain abstracts away.
+
+1. **Ingest a PDF** — run `manual/ingest.py` to extract text from `data/info.pdf`, chunk it, and upsert into Pinecone.
+   ```bash
+   cd manual
+   python ingest.py
+   ```
+2. **Query** — run `manual/query.py` to ask a single question and get a concise answer.
+   ```bash
+   python query.py
+   ```
+
+| Component | Detail |
+|---|---|
+| Embedding model | `nomic-embed-text:latest` (768 dims) |
+| LLM | `qwen2.5:0.5b` |
+| Index name | `pdf-rag-test` |
 
 ## File Structure
 
 ```
 .
 ├── data/
-│   └── faq.json
+│   ├── faq.json          # FAQ dataset (used by lang/)
+│   └── info.pdf          # PDF document (used by manual/)
 ├── lang/
-│   ├── ingest.py
-│   └── main.py
+│   ├── ingest.py         # LangChain-based FAQ ingestion
+│   └── main.py           # LangChain-based interactive Q&A
+├── manual/
+│   ├── ingest.py         # Direct-API PDF ingestion
+│   └── query.py          # Direct-API single-question query
 ├── requirements.txt
-├── .env
+├── .env                  # Environment variables (not committed)
 └── README.md
 ```
 
 ## Notes
 
-- Make sure your Pinecone index dimension matches your embedding model output.
+- Make sure your Pinecone index dimension matches your embedding model output (`lang/` uses 384, `manual/` uses 768).
 - For best results, store both questions and answers together in each document.
 - You can adjust chunk size and retrieval parameters in the code.

--- a/lang/ingest.py
+++ b/lang/ingest.py
@@ -1,12 +1,12 @@
-"""Ingest FAQ data into Pinecone using LangChain.
+"""FAQ-gegevens opnemen in Pinecone met LangChain.
 
-Reads question-answer pairs from ``data/faq.json``, wraps each pair in a
-LangChain ``Document``, generates embeddings via Ollama, and upserts the
-vectors into a Pinecone serverless index.
+Leest vraag-antwoordparen uit ``data/faq.json``, verpakt elk paar in een
+LangChain ``Document``, genereert embeddings via Ollama en voegt de vectoren
+toe aan een Pinecone serverless index.
 
-Required environment variables (set in ``.env``):
-    PINECONE_API_KEY – Pinecone API key.
-    OLLAMA_API_URL   – Base URL of the Ollama instance (e.g. http://localhost:11434).
+Vereiste omgevingsvariabelen (in te stellen in ``.env``):
+    PINECONE_API_KEY -- Pinecone API-sleutel.
+    OLLAMA_API_URL   -- Basis-URL van de Ollama-instantie (bijv. http://localhost:11434).
 """
 
 import os

--- a/lang/ingest.py
+++ b/lang/ingest.py
@@ -1,3 +1,14 @@
+"""Ingest FAQ data into Pinecone using LangChain.
+
+Reads question-answer pairs from ``data/faq.json``, wraps each pair in a
+LangChain ``Document``, generates embeddings via Ollama, and upserts the
+vectors into a Pinecone serverless index.
+
+Required environment variables (set in ``.env``):
+    PINECONE_API_KEY – Pinecone API key.
+    OLLAMA_API_URL   – Base URL of the Ollama instance (e.g. http://localhost:11434).
+"""
+
 import os
 import json
 from dotenv import load_dotenv

--- a/lang/main.py
+++ b/lang/main.py
@@ -1,3 +1,14 @@
+"""Interactive RAG query loop using LangChain, Pinecone, and Ollama.
+
+Connects to an existing Pinecone index (populated by ``ingest.py``), retrieves
+the top-k most relevant documents for a user's question, and generates an
+answer with a local Ollama LLM.
+
+Required environment variables (set in ``.env``):
+    PINECONE_API_KEY – Pinecone API key.
+    OLLAMA_API_URL   – Base URL of the Ollama instance (e.g. http://localhost:11434).
+"""
+
 import os
 from dotenv import load_dotenv
 

--- a/lang/main.py
+++ b/lang/main.py
@@ -1,12 +1,12 @@
-"""Interactive RAG query loop using LangChain, Pinecone, and Ollama.
+"""Interactieve RAG-querylus met LangChain, Pinecone en Ollama.
 
-Connects to an existing Pinecone index (populated by ``ingest.py``), retrieves
-the top-k most relevant documents for a user's question, and generates an
-answer with a local Ollama LLM.
+Maakt verbinding met een bestaande Pinecone-index (gevuld door ``ingest.py``),
+haalt de top-k meest relevante documenten op voor de vraag van een gebruiker
+en genereert een antwoord met een lokaal Ollama LLM.
 
-Required environment variables (set in ``.env``):
-    PINECONE_API_KEY – Pinecone API key.
-    OLLAMA_API_URL   – Base URL of the Ollama instance (e.g. http://localhost:11434).
+Vereiste omgevingsvariabelen (in te stellen in ``.env``):
+    PINECONE_API_KEY -- Pinecone API-sleutel.
+    OLLAMA_API_URL   -- Basis-URL van de Ollama-instantie (bijv. http://localhost:11434).
 """
 
 import os

--- a/manual/ingest.py
+++ b/manual/ingest.py
@@ -1,3 +1,14 @@
+"""Ingest a PDF into Pinecone without LangChain.
+
+Extracts text from ``data/info.pdf``, splits it into fixed-size word chunks,
+generates embeddings via the Ollama REST API, and upserts the vectors into a
+Pinecone index.
+
+Required environment variables (set in ``.env``):
+    PINECONE_API_KEY – Pinecone API key.
+    OLLAMA_API_URL   – Base URL of the Ollama instance (e.g. http://localhost:11434).
+"""
+
 import PyPDF2
 import requests
 import os
@@ -19,6 +30,7 @@ with open(pdf_path, "rb") as f:
         text += page.extract_text() + "\n"
 
 def chunk_text(text, chunk_size=75):
+    """Split *text* into chunks of *chunk_size* words."""
     words = text.split()
     chunks = [] 
     for i in range(0, len(words), chunk_size):

--- a/manual/ingest.py
+++ b/manual/ingest.py
@@ -1,12 +1,12 @@
-"""Ingest a PDF into Pinecone without LangChain.
+"""Een PDF opnemen in Pinecone zonder LangChain.
 
-Extracts text from ``data/info.pdf``, splits it into fixed-size word chunks,
-generates embeddings via the Ollama REST API, and upserts the vectors into a
-Pinecone index.
+Extraheert tekst uit ``data/info.pdf``, splitst deze in chunks van een vast
+aantal woorden, genereert embeddings via de Ollama REST API en voegt de
+vectoren toe aan een Pinecone-index.
 
-Required environment variables (set in ``.env``):
-    PINECONE_API_KEY – Pinecone API key.
-    OLLAMA_API_URL   – Base URL of the Ollama instance (e.g. http://localhost:11434).
+Vereiste omgevingsvariabelen (in te stellen in ``.env``):
+    PINECONE_API_KEY -- Pinecone API-sleutel.
+    OLLAMA_API_URL   -- Basis-URL van de Ollama-instantie (bijv. http://localhost:11434).
 """
 
 import PyPDF2
@@ -21,7 +21,7 @@ api_key = os.getenv("PINECONE_API_KEY")
 
 pc = Pinecone(api_key=api_key)
 
-# Load in a PDF and split it into chunks of 75 words
+# Laad een PDF in en splits deze in chunks van 75 woorden
 pdf_path = "../data/info.pdf"
 text = ""
 with open(pdf_path, "rb") as f:
@@ -30,7 +30,7 @@ with open(pdf_path, "rb") as f:
         text += page.extract_text() + "\n"
 
 def chunk_text(text, chunk_size=75):
-    """Split *text* into chunks of *chunk_size* words."""
+    """Splits *text* op in chunks van *chunk_size* woorden."""
     words = text.split()
     chunks = [] 
     for i in range(0, len(words), chunk_size):
@@ -40,7 +40,7 @@ def chunk_text(text, chunk_size=75):
 
 chunks = chunk_text(text)
 
-# Create embeddings for each chunk
+# Maak embeddings aan voor elke chunk
 embeddings = []
 for chunk in chunks:
     response = requests.post(
@@ -49,7 +49,7 @@ for chunk in chunks:
     )
     embeddings.append(response.json()["embedding"])
 
-# Create index and upsert vectors
+# Index aanmaken en vectoren upserten
 index_name = "pdf-rag-test"
 indexes = pc.list_indexes()
 existing_names = [idx["name"] for idx in indexes]
@@ -58,7 +58,7 @@ if index_name not in existing_names:
     dim = 768
     pc.create_index(name=index_name, dimension=dim, metric="cosine")
 else:
-    print(f"Index '{index_name}' already exists, skipping creation.")
+    print(f"Index '{index_name}' bestaat al, aanmaken overgeslagen.")
 
 index = pc.Index(index_name)
 
@@ -70,4 +70,4 @@ items_to_upsert = [
 index.upsert(
     vectors=items_to_upsert
 )
-print("Vectors upserted!")
+print("Vectoren toegevoegd!")

--- a/manual/query.py
+++ b/manual/query.py
@@ -1,13 +1,13 @@
-"""Query the Pinecone index and generate an answer without LangChain.
+"""De Pinecone-index bevragen en een antwoord genereren zonder LangChain.
 
-Embeds a user question via the Ollama REST API, queries Pinecone for the
-top-k matching chunks, and sends the retrieved context plus the question to
-a local Ollama LLM to produce a concise answer.
+Embed een gebruikersvraag via de Ollama REST API, bevraagt Pinecone voor de
+top-k overeenkomende chunks en stuurt de opgehaalde context samen met de
+vraag naar een lokaal Ollama LLM om een beknopt antwoord te genereren.
 
-Required environment variables (set in ``.env``):
-    PINECONE_API_KEY – Pinecone API key.
-    PINECONE_HOST    – Pinecone index host URL.
-    OLLAMA_API_URL   – Base URL of the Ollama instance (e.g. http://localhost:11434).
+Vereiste omgevingsvariabelen (in te stellen in ``.env``):
+    PINECONE_API_KEY -- Pinecone API-sleutel.
+    PINECONE_HOST    -- Pinecone index host-URL.
+    OLLAMA_API_URL   -- Basis-URL van de Ollama-instantie (bijv. http://localhost:11434).
 """
 
 from pinecone import Pinecone
@@ -43,7 +43,7 @@ results = index.query(
 matches = results['matches']
 top_context = "\n\n".join(match['metadata']['text'] for match in matches)
 
-# Structure the prompt using the context and question
+# Structureer de prompt met de context en de vraag
 llm_prompt = f"""
 You are an expert assistant. Use the context below to answer the question as concisely as possible.
 If the answer is not contained in the context, say: "I don't know."
@@ -56,7 +56,7 @@ Question: {question}
 Answer (concise):
 """
 
-# Call the LLM
+# Roep het LLM aan
 llm_response = requests.post(
     ollama_api_url + "/api/generate",
     json={

--- a/manual/query.py
+++ b/manual/query.py
@@ -1,3 +1,15 @@
+"""Query the Pinecone index and generate an answer without LangChain.
+
+Embeds a user question via the Ollama REST API, queries Pinecone for the
+top-k matching chunks, and sends the retrieved context plus the question to
+a local Ollama LLM to produce a concise answer.
+
+Required environment variables (set in ``.env``):
+    PINECONE_API_KEY – Pinecone API key.
+    PINECONE_HOST    – Pinecone index host URL.
+    OLLAMA_API_URL   – Base URL of the Ollama instance (e.g. http://localhost:11434).
+"""
+
 from pinecone import Pinecone
 import requests
 from dotenv import load_dotenv


### PR DESCRIPTION
De README en alle Python-docstrings waren alleen in het Engels beschikbaar. Deze PR voegt Nederlandstalige documentatie toe aan het hele project.

## Aanpak

- Alle documentatie (README, module docstrings, inline comments en printberichten) is vertaald naar het Nederlands.
- De README documenteert nu beide pipelines (`lang/` en `manual/`) met gebruiksinstructies, modeldetails en een bijgewerkte bestandsstructuur.
- Technische termen (LangChain, Pinecone, embeddings, chunks, etc.) zijn bewust in het Engels gelaten omdat dit de standaard terminologie is.